### PR TITLE
add uv inline metadata for dependencies

### DIFF
--- a/css2rss.py
+++ b/css2rss.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "beautifulsoup4",
+#     "maya",
+# ]
+# ///
 # CSS2RSS
 # input html file must be provided in stdin
 # arguments: item, item title, item description, item link, item title 2nd part, item date


### PR DESCRIPTION
Hi, 
thanks for sharing your work!

I added inline metadata for [uv](https://github.com/astral-sh/uv/), a great and very fast pyhon manager.
With this metadata, it allows for using the script directly without manually having to install any dependencies or even any specific python versions itself. You do still need uv though, of course. 

For the inline metadata to do anything, the script must be run with `uv run` instead of `python`. Execution example:

It first installs the dependencies and then runs the script
```powershell
 curl "https://www.foxnews.com/media" | uv run .\css2rss.py ".title > a" > out
⠋ Resolving dependencies...
⠙ Resolving dependencies...
Total   ⠋ Resolving dependencies...
⠙ Resolving dependencies...
⠙ beautifulsoup4==4.12.3
⠙ maya==0.6.1
⠙ soupsieve==2.6
⠙ humanize==4.11.0
⠙ pytz==2024.2
⠙ dateparser==1.2.0
⠙ tzlocal==5.2
⠙ pendulum==3.0.0
 Time  Current
⠙ snaptime==0.2.4
⠙ python-dateutil==2.9.0.post0
⠙ regex==2024.11.6
⠙ tzdata==2024.2
⠙ tzdata==2024.2
⠙ time-machine==2.16.0
⠙ time-machine==2.16.0
⠙ six==1.17.0
eed
⠙
100  384k  100  384k    0     0  1087k      0 --:--:-- --:--:-- --:--:-- 1097k
```

The output is as expected
```json
 cat out | jq
{
  "version": "https://jsonfeed.org/version/1.1",
  "title": "Media News & Industry Updates  | Fox News",
  "description": "Script found 125 items",
  "items": [
    {
      "title": "CNN defamation trial: Losing case expected but still a bad bruise for the network, insider says",
      "content_html": "<a href=\"/media/cnn-defamation-trial-losing-case-expected-still-bad-bruise-network-insider-says\">CNN defamation trial: Losing case expected but still a bad bruise for the network, insider says</a>",
      "url": "/media/cnn-defamation-trial-losing-case-expected-still-bad-bruise-network-insider-says",
      "date_published": ""
    },
    {
      "title": "MSNBC's Biden interview loses out to comedy reruns in ratings",
      "content_html": "<a href=\"/media/msnbcs-biden-interview-loses-out-comedy-reruns-ratings\">MSNBC's Biden interview loses out to comedy reruns in ratings</a>",
      "url": "/media/msnbcs-biden-interview-loses-out-comedy-reruns-ratings",
      "date_published": ""
    },
    {
      "title": "Biden relied on teleprompters even during private fundraisers: Report",
      "content_html": "<a href=\"/media/biden-allegedly-used-teleprompters-small-fundraisers-private-homes-alarming-donors-nyt-report\">Biden relied on teleprompters even during private fundraisers: Report</a>",
      "url": "/media/biden-allegedly-used-teleprompters-small-fundraisers-private-homes-alarming-donors-nyt-report",
      "date_published": ""
    },
```

Resolving the dependencies is done on every launch, but is blazingly fast, especially with a warm package cache, the entire command is done in 230 milliseconds, and 158ms of that are just the curl request..
```powershell
 Measure-Command {curl "https://www.foxnews.com/media" | uv run .\css2rss.py ".title > a" }
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
            ⠋ Resolving dependencies...
⠙ Resolving dependencies...
      ⠋ Resolving dependencies...
⠙ Resolving dependencies...
⠙ beautifulsoup4==4.12.3
⠙ maya==0.6.1
⠙ soupsieve==2.6
⠙ humanize==4.11.0
⠙ pytz==2024.2
⠙ dateparser==1.2.0
⠙ tzlocal==5.2
⠙ pendulum==3.0.0
eed
⠙ snaptime==0.2.4
⠙ python-dateutil==2.9.0.post0
⠙ regex==2024.11.6
⠙ tzdata==2024.2
⠙ tzdata==2024.2
100  383k  100  383k    0     0  2499k      0 --:--:-- --:--:-- --:--:-- 2542k

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 230
Ticks             : 2309982
TotalDays         : 2.67359027777778E-06
TotalHours        : 6.41661666666667E-05
TotalMinutes      : 0.00384997
TotalSeconds      : 0.2309982
TotalMilliseconds : 230.9982

 Measure-Command {curl "https://www.foxnews.com/media" }
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  383k  100  383k    0     0  2625k      0 --:--:-- --:--:-- --:--:-- 2666k

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 158
Ticks             : 1589949
TotalDays         : 1.84021875E-06
TotalHours        : 4.416525E-05
TotalMinutes      : 0.002649915
TotalSeconds      : 0.1589949
TotalMilliseconds : 158.9949
```
